### PR TITLE
Update Github Workflow Container Build Process for expanded OS support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,4 +43,4 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository_owner }}/nc-dmv-scraper:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,20 +27,36 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/nc-dmv-scraper
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and push multi-arch container for ${{ github.repository }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/nc-dmv-scraper:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,15 +21,26 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
 
-      # https://github.com/marketplace/actions/push-to-ghcr
-      - name: Build and publish a Docker image for ${{ github.repository }}
-        uses: macbre/push-to-ghcr@v14
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          image_name: ${{ github.repository }}  # it will be lowercased internally
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # optionally push to the Docker Hub (docker.io)
-          # docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security
-          # customize the username to be used when pushing to the Docker Hub
-          # docker_io_user: foobar  # see https://github.com/macbre/push-to-ghcr/issues/14
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch container for ${{ github.repository }}
+        uses: docker/build-push-action@v3
+        with:
+          context: ./docker
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/nc-dmv-scraper:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build and push multi-arch container for ${{ github.repository }}
         uses: docker/build-push-action@v3
         with:
-          context: ./docker
+          context: .
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,4 +43,4 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/nc-dmv-scraper:latest
+            ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
- Replaces macbre/push-to-ghcr with docker/build-push-action for building and publishing multi-architecture images. 
- Builds images for multiple OS arch to add broader support across use platforms - 386, amd64 ,arm/v7, arm64
- Adds steps for setting up Buildx and authenticating to GitHub Container Registry, improving compatibility and flexibility.
- Adds docker/metadata-action for automated image tagging and labeling.
- Enables build cache, provenance, and SBOM generation for improved container build efficiency and security.